### PR TITLE
Separate delimiters from fragments option

### DIFF
--- a/src/Diff.php
+++ b/src/Diff.php
@@ -18,12 +18,12 @@
 
 namespace CogPowered\FineDiff;
 
-use CogPowered\FineDiff\Granularity\GranularityInterface;
-use CogPowered\FineDiff\Render\RendererInterface;
-use CogPowered\FineDiff\Parser\ParserInterface;
 use CogPowered\FineDiff\Granularity\Character;
-use CogPowered\FineDiff\Render\Html;
+use CogPowered\FineDiff\Granularity\GranularityInterface;
 use CogPowered\FineDiff\Parser\Parser;
+use CogPowered\FineDiff\Parser\ParserInterface;
+use CogPowered\FineDiff\Render\Html;
+use CogPowered\FineDiff\Render\RendererInterface;
 
 /**
  * Diff class.
@@ -48,11 +48,12 @@ class Diff
     /**
      * Instantiate a new instance of Diff.
      *
-     * @param \CogPowered\FineDiff\Granularity\GranularityInterface $granularity    Level of diff.
-     * @param \CogPowered\FineDiff\Render\RendererInterface         $renderer       Diff renderer.
-     * @param \CogPowered\FineDiff\Parser\ParserInterface           $parser         Parser used to generate operation codes.
+     * @param \CogPowered\FineDiff\Granularity\GranularityInterface $granularity Level of diff.
+     * @param \CogPowered\FineDiff\Render\RendererInterface $renderer Diff renderer.
+     * @param \CogPowered\FineDiff\Parser\ParserInterface $parser Parser used to generate operation codes.
+     * @param bool $separateDelimiters Separate delimiters from fragments
      */
-    public function __construct(GranularityInterface $granularity = null, RendererInterface $renderer = null, ParserInterface $parser = null)
+    public function __construct(GranularityInterface $granularity = null, RendererInterface $renderer = null, ParserInterface $parser = null, $separateDelimiters = false)
     {
         // Set some sensible defaults
 
@@ -63,7 +64,7 @@ class Diff
         $this->renderer = ($renderer !== null) ? $renderer : new Html;
 
         // Set the diff parser
-        $this->parser = ($parser !== null) ? $parser : new Parser($this->granularity);
+        $this->parser = ($parser !== null) ? $parser : new Parser($this->granularity, $separateDelimiters);
     }
 
     /**
@@ -85,6 +86,28 @@ class Diff
     public function setGranularity(GranularityInterface $granularity)
     {
         $this->parser->setGranularity($granularity);
+    }
+
+    /**
+     * Get the separate delimiters from fragments option
+     *
+     * @return bool
+     */
+    public function getSeparateDelimiters()
+    {
+        return $this->parser->getSeparateDelimiters();
+    }
+
+    /**
+     * Set the separate delimiters from fragments option
+     *
+     * @param bool $separateDelimiters
+     *
+     * @return void
+     */
+    public function setSeparateDelimiters($separateDelimiters)
+    {
+        $this->parser->setSeparateDelimiters($separateDelimiters);
     }
 
     /**

--- a/src/Parser/ParserInterface.php
+++ b/src/Parser/ParserInterface.php
@@ -25,9 +25,10 @@ interface ParserInterface
     /**
      * Creates an instance.
      *
-     * @param \CogPowered\FineDiff\Granularity\GranularityInterface
+     * @param \CogPowered\FineDiff\Granularity\GranularityInterface $granularity
+     * @param bool $separateDelimiters Separate delimiters from fragments
      */
-    public function __construct(GranularityInterface $granularity);
+    public function __construct(GranularityInterface $granularity, $separateDelimiters = false);
 
     /**
      * Granularity the parser is working with.
@@ -72,6 +73,22 @@ interface ParserInterface
      * @return void
      */
     public function setOperationCodes(OperationCodesInterface $operation_codes);
+
+    /**
+     * Get the separate delimiters from fragments option
+     *
+     * @return bool
+     */
+    public function getSeparateDelimiters();
+
+    /**
+     * Set the separate delimiters from fragments option
+     *
+     * @param bool $separateDelimiters
+     *
+     * @return void
+     */
+    public function setSeparateDelimiters($separateDelimiters);
 
     /**
      * Generates the operation codes needed to transform one string to another.

--- a/tests/Diff/SetTest.php
+++ b/tests/Diff/SetTest.php
@@ -66,4 +66,18 @@ class SetTest extends TestCase
         $granularity = $this->diff->getGranularity();
         $granularity->fooBar();
     }
+
+    public function testDefaultSeparateDelimiters()
+    {
+        $this->assertFalse($this->diff->getSeparateDelimiters());
+    }
+
+    public function testParseSetSeparateDelimiters()
+    {
+        $this->diff->setSeparateDelimiters(true);
+        $this->assertTrue($this->diff->getSeparateDelimiters());
+
+        $this->diff->setSeparateDelimiters(false);
+        $this->assertFalse($this->diff->getSeparateDelimiters());
+    }
 }

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -68,4 +68,18 @@ class ParserTest extends TestCase
         
         $this->assertTrue(true);
     }
+
+    public function testDefaultSeparateDelimiters()
+    {
+        $this->assertFalse($this->parser->getSeparateDelimiters());
+    }
+
+    public function testParseSetSeparateDelimiters()
+    {
+        $this->parser->setSeparateDelimiters(true);
+        $this->assertTrue($this->parser->getSeparateDelimiters());
+
+        $this->parser->setSeparateDelimiters(false);
+        $this->assertFalse($this->parser->getSeparateDelimiters());
+    }
 }

--- a/tests/Usage/Resources/paragraph/separate/simple.txt
+++ b/tests/Usage/Resources/paragraph/separate/simple.txt
@@ -1,0 +1,10 @@
+This is the 1st sentence. Its then carried on into another.
+This is another paragraph, just to test things further!
+==========
+This is the 1st sentence. It then carries on into another.
+This is another paragraph, just to test things further!
+==========
+d59i58:This is the 1st sentence. It then carries on into another.c56
+==========
+<del>This is the 1st sentence. Its then carried on into another.</del><ins>This is the 1st sentence. It then carries on into another.</ins>
+This is another paragraph, just to test things further!

--- a/tests/Usage/Resources/sentence/separate/simple.txt
+++ b/tests/Usage/Resources/sentence/separate/simple.txt
@@ -1,0 +1,10 @@
+This is the 1st sentence. Its then carried on into another.
+This is another paragraph, just to test things further!
+==========
+This is the 1st sentence. It then carries on into another.
+This is another paragraph, just to test things further!
+==========
+c25d33i32: It then carries on into anotherc57
+==========
+This is the 1st sentence.<del> Its then carried on into another</del><ins> It then carries on into another</ins>.
+This is another paragraph, just to test things further!

--- a/tests/Usage/Resources/word/separate/simple.txt
+++ b/tests/Usage/Resources/word/separate/simple.txt
@@ -1,0 +1,10 @@
+This is the 1st sentence. Its then carried on into another.
+This is another paragraph, just to test things further!
+==========
+This is the 1st sentence. It then carries on into another.
+This is another paragraph, just to test things further!
+==========
+c26d3i2:Itc6d7i7:carriesc73
+==========
+This is the 1st sentence. <del>Its</del><ins>It</ins> then <del>carried</del><ins>carries</ins> on into another.
+This is another paragraph, just to test things further!

--- a/tests/Usage/SeparateSimpleTest.php
+++ b/tests/Usage/SeparateSimpleTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace FineDiffTests\Usage;
+
+use CogPowered\FineDiff\Diff;
+use CogPowered\FineDiff\Granularity\GranularityInterface;
+use CogPowered\FineDiff\Render\Text;
+use CogPowered\FineDiff\Render\Html;
+use CogPowered\FineDiff\Granularity\Character;
+use CogPowered\FineDiff\Granularity\Word;
+use CogPowered\FineDiff\Granularity\Sentence;
+use CogPowered\FineDiff\Granularity\Paragraph;
+
+class SeparateSimpleTest extends Base
+{
+    protected static function createDiff(GranularityInterface $granularity)
+    {
+        return new Diff($granularity, null, null, true);
+    }
+
+    public function testInsertCharacterGranularity()
+    {
+        list($from, $to, $operation_codes, $html) = $this->getFile('character/simple');
+
+        $diff = self::createDiff(new Character);
+        $generated_operation_codes = $diff->getOperationCodes($from, $to);
+
+
+        // Generate operation codes
+        $this->assertEquals($generated_operation_codes, $operation_codes);
+
+        // Render to text from operation codes
+        $render = new Text;
+        $this->assertEquals( $render->process($from, $generated_operation_codes), $to );
+
+        // Render to html from operation codes
+        $render = new Html;
+        $this->assertEquals( $render->process($from, $generated_operation_codes), $html );
+
+        // Render
+        $this->assertEquals( $diff->render($from, $to), $html );
+    }
+
+    public function testInsertWordGranularity()
+    {
+        list($from, $to, $operation_codes, $html) = $this->getFile('word/separate/simple');
+
+        $diff = self::createDiff(new Word);
+        $generated_operation_codes = $diff->getOperationCodes($from, $to);
+
+
+        // Generate operation codes
+        $this->assertEquals($generated_operation_codes, $operation_codes);
+
+        // Render to text from operation codes
+        $render = new Text;
+        $this->assertEquals( $render->process($from, $generated_operation_codes), $to );
+
+        // Render to html from operation codes
+        $render = new Html;
+        $this->assertEquals( $render->process($from, $generated_operation_codes), $html );
+
+        // Render
+        $this->assertEquals( $diff->render($from, $to), $html );
+    }
+
+    public function testInsertSentenceGranularity()
+    {
+        list($from, $to, $operation_codes, $html) = $this->getFile('sentence/separate/simple');
+
+        $diff = self::createDiff(new Sentence);
+        $generated_operation_codes = $diff->getOperationCodes($from, $to);
+
+
+        // Generate operation codes
+        $this->assertEquals($generated_operation_codes, $operation_codes);
+
+        // Render to text from operation codes
+        $render = new Text;
+        $this->assertEquals( $render->process($from, $generated_operation_codes), $to );
+
+        // Render to html from operation codes
+        $render = new Html;
+        $this->assertEquals( $render->process($from, $generated_operation_codes), $html );
+
+        // Render
+        $this->assertEquals( $diff->render($from, $to), $html );
+    }
+
+    public function testInsertParagraphGranularity()
+    {
+        list($from, $to, $operation_codes, $html) = $this->getFile('paragraph/separate/simple');
+
+        $diff = self::createDiff(new Paragraph);
+        $generated_operation_codes = $diff->getOperationCodes($from, $to);
+
+
+        // Generate operation codes
+        $this->assertEquals($generated_operation_codes, $operation_codes);
+
+        // Render to text from operation codes
+        $render = new Text;
+        $this->assertEquals( $render->process($from, $generated_operation_codes), $to );
+
+        // Render to html from operation codes
+        $render = new Html;
+        $this->assertEquals( $render->process($from, $generated_operation_codes), $html );
+
+        // Render
+        $this->assertEquals( $diff->render($from, $to), $html );
+    }
+}


### PR DESCRIPTION
Adds separate delimiters from fragments option

Allows to compare delimiters separately from words.

Current behavior (without separate delimiters):
Change `Hello` to `Hello world` produces `<del>Hello</del><ins>Hello world</ins>`

New behavior (with separate delimiters):
Change `Hello` to `Hello world` produces `Hello<ins> world</ins>`
